### PR TITLE
Update modman

### DIFF
--- a/modman
+++ b/modman
@@ -4,7 +4,7 @@ app/design/adminhtml/default/default/locale/de_DE/translate.csv app/design/admin
 app/design/frontend/default/default/locale/de_DE/translate.csv app/design/frontend/base/default/locale/de_DE/translate.csv
 app/etc/modules/German_LocalePackDe.xml app/etc/modules/German_LocalePackDe.xml
 
-app/locale/de_DE/       app/locale/de_DE/
+app/locale/de_DE/*       app/locale/de_DE/
 
 downloader/template_de  downloader/template_de
 


### PR DESCRIPTION
Es sollten nur die Dateien des Ordners de_DE nach Magento gelinkt werden da es sonst einen Konflikt mit Modulen gibt welche ebenfalls Dateien in de_DE linken möchten.
