### PR TITLE
"Best Value" meint eigentlich Position

### DIFF
--- a/app/locale/de_DE/Mage_Catalog.csv
+++ b/app/locale/de_DE/Mage_Catalog.csv
@@ -112,7 +112,7 @@
 "Backorders","Nachlieferungen"
 "Based On","Kopieren von"
 "Before Order Confirmation","Vor der Bestellbestätigung"
-"Best Value","Bewertung"
+"Best Value","Position"
 "Block after Info Column","Block nach der Info-Spalte"
 "Bottom Block Options Wrapper","Unterer Options-Block Container"
 "Bottom/Left","Unten links"


### PR DESCRIPTION
Das ist eigentlich mehr oder weniger ein Magento Bug. Verwendet wird der String nur in "Product Listing Sort by" im Backend.
Gemeint ist hier tatsächlich die Artikel Position. Angeglichen so wie es im Frontend ist.
