### PR TITLE
Removed wrong translation of manufacturer in admin

### DIFF
--- a/app/design/adminhtml/default/default/locale/de_DE/translate.csv
+++ b/app/design/adminhtml/default/default/locale/de_DE/translate.csv
@@ -247,7 +247,6 @@
 "Display product options in","Artikeloptionen anzeigen in"
 "Price View","Preis Ansicht"
 "Country of Manufacture","Herstellungsland"
-"Manufacturer","UVP"
 "Display Actual Price","Tatsächlicher Preis"
 "Apply MAP","UVP anwenden"
 "Base Image Label","Bild ALT Text"


### PR DESCRIPTION
Removed translation manufaturer -> UVP. Correct translation is in #236 so there is no need to replace it.
