### PR TITLE
Update Mage_Checkout.csv

### DIFF
--- a/app/locale/de_DE/Mage_Checkout.csv
+++ b/app/locale/de_DE/Mage_Checkout.csv
@@ -59,7 +59,7 @@
 "Checkout with Multiple Addresses","Zur Kasse mit mehreren Adressen"
 "City","Stadt"
 "Clear Shopping Cart","Warenkorb leeren"
-"Click <a href=""%s"" onclick=""this.target='_blank'"">here to print</a> a copy of your order confirmation.","<a href=""%s"" onclick=""this.target=\'_blank\'"">Klicken Sie hier</a>, um eine Kopie Ihrer Bestellbestätigung zu drucken."
+"Click <a href=""%s"" onclick=""this.target='_blank'"">here to print</a> a copy of your order confirmation.","<a href=""%s"" onclick=""this.target='_blank'"">Klicken Sie hier</a>, um eine Kopie Ihrer Bestellbestätigung zu drucken."
 "Click <a href=""%s"">here</a> to continue shopping.","Klicken Sie <a href=""%s"">hier</a> um den Einkauf fortzusetzen."
 "Close","Schließen"
 "Company","Firma"


### PR DESCRIPTION
As far as I understand this it is because the corresponding template (success.phtml) already replaces the \’ during interpretation. See http://www.magentocommerce.com/boards/viewthread/7301/ for more details
