### PR TITLE
Fehlende Statusmeldung nach dem versenden der Passwort zurücksetzen

### DIFF
--- a/app/locale/de_DE/Mage_Customer.csv
+++ b/app/locale/de_DE/Mage_Customer.csv
@@ -171,6 +171,7 @@
 "Hello, %s!","Hallo, %s!"
 "ID","ID"
 "IP Address","IP Adresse"
+"If there is an account associated with %s you will receive an email with a link to reset your password.","Sollten wir einen Account unter %s finden können, erhalten Sie eine E-Mail mit einem Link, mit dem Sie Ihr Passwort zurücksetzen können."
 "If you believe this is an error, please contact us at %s","Wenn Sie dies für einen Fehler halten, nehmen Sie bitte Kontakt unter %s mit uns auf"
 "If you have an account with us, please log in.","Wenn Sie bei uns ein Benutzerkonto besitzen, melden Sie sich bitte an."
 "Invalid attribute option specified for attribute %s (%s), skipping the record.","Ungültige Attributoption für Attribut %s (%s) angegeben, Zeile wird übersprungen"


### PR DESCRIPTION
 Der Text existiert bereits in der Mage_Adminhtml.csv, aber im Frontend fehlt diese Übersetzung, da es aus Mage_Customer.csv kommen muss. 

Ist es so OK?
