### PR TITLE
added missing tanslations for Mage_Customer, eg. password reset

### DIFF
--- a/app/code/community/German/LocalePackDe/etc/config.xml
+++ b/app/code/community/German/LocalePackDe/etc/config.xml
@@ -77,4 +77,16 @@
         </acl>
     </adminhtml>
 
+    <frontend>
+        <translate>
+            <modules>
+                <Mage_Customer>
+                    <files>
+                        <germanlocalepack>Mage_Customer.germanlocalepack.csv</germanlocalepack>
+                    </files>
+                </Mage_Customer>
+            </modules>
+        </translate>
+    </frontend>
+
 </config>

--- a/app/locale/de_DE/Mage_Customer.germanlocalepack.csv
+++ b/app/locale/de_DE/Mage_Customer.germanlocalepack.csv
@@ -1,0 +1,2 @@
+"If there is an account associated with %s you will receive an email with a link to reset your password.","Sollten wir einen Account unter %s finden können, erhalten Sie eine E-Mail mit einem Link, mit dem Sie Ihr Passwort zurücksetzen können."
+"Your password has been updated.","Ihr Passwort wurde geändert."


### PR DESCRIPTION
In der Originalen Übersetzung von Magento (en_US) fehlen diese Übersetzungen auch.
Daher die neue Datei
