### PR TITLE
Revert "added missing translation"

### DIFF
--- a/app/locale/de_DE/Mage_Customer.csv
+++ b/app/locale/de_DE/Mage_Customer.csv
@@ -460,7 +460,6 @@
 "Your Tax ID cannot be validated.","Ihre USt-IdNr. konnte nicht überprüft werden."
 "Your VAT ID was successfully validated.","Ihre USt-IdNr. wurde erfolgreich überprüft."
 "Your account balance is: %s","Ihr Kontostand beträgt: %s"
-"Your password has been updated.","Ihr Passwort wurde geändert."
 "ZIP","Postleitzahl"
 "ZIP/Post Code","Postleitzahl"
 "Zip/Postal Code","PLZ"


### PR DESCRIPTION
Da mit #139 eine neue Datei für Übersetzungen aus Mage_Customer erstellt wurde, die nicht in en_US enthalten sind, sollte diese Übersetzung wieder entfernt werden da nun doppelt.

This reverts commit c65ac3dd1f071aa16ee1f9a8dcb02bb68df7ccc7 (#131).
