### PR TITLE
added missing translation for Mage_Wishlist

### DIFF
--- a/app/code/community/German/LocalePackDe/etc/config.xml
+++ b/app/code/community/German/LocalePackDe/etc/config.xml
@@ -85,6 +85,11 @@
                         <germanlocalepack>Mage_Customer.germanlocalepack.csv</germanlocalepack>
                     </files>
                 </Mage_Customer>
+                <Mage_Wishlist>
+                    <files>
+                        <germanlocalepack>Mage_Wishlist.germanlocalepack.csv</germanlocalepack>
+                    </files>
+                </Mage_Wishlist>
             </modules>
         </translate>
     </frontend>

--- a/app/locale/de_DE/Mage_Wishlist.germanlocalepack.csv
+++ b/app/locale/de_DE/Mage_Wishlist.germanlocalepack.csv
@@ -1,0 +1,1 @@
+"%1$s has been added to your wishlist. Click <a href=""%2$s"">here</a> to continue shopping.","%1$s wurde Ihrem Wunschzettel hinzugefügt. Klicken Sie <a href=""%2$s"">hier</a> um weiter einzukaufen."


### PR DESCRIPTION
Definiert in Mage_Wishlist_IndexController, nicht vorhanden in en_US/Mage_Wishlist.csv

Betrifft Magento in Version 1.9.0.1 und 1.9.1.0