### PR TITLE
fix dublicate entry "Credit Memo # "

### DIFF
--- a/app/locale/de_DE/Mage_Sales.csv
+++ b/app/locale/de_DE/Mage_Sales.csv
@@ -168,7 +168,7 @@
 "Created billing agreement #%s.","Zahlungsvereinbarung #%s erstellt."
 "Created:","Erstellt:"
 "Credit Memo","Rechnungskorrektur"
-"Credit Memo # ","Rechnungskorrektur Nr. "
+"Credit Memo #","Rechnungskorrektur Nr."
 "Credit Memo # ","Rechnungskorrektur Nr. "
 "Credit Memo #%1$s | %3$s | %2$s (%4$s)","Rechnungskorrektur #%1$s | %3$s | %2$s (%4$s)"
 "Credit Memo Comment Email Sender","Absender Kommentar-Rechnungskorrektur-E-Mail"


### PR DESCRIPTION
In der *Mage_Sales.csv* ist der Eintrag "Credit Memo # " doppelt vorhanden, während der Eintrag ohne Leerzeichen fehlt, aber bspw. in *app\code\core\Mage\Adminhtml\Block\Sales\Creditmemo\Grid.php:64* von Magento 1.9.0.1 verwendet wird.