### PR TITLE
the word Stati does not exist in German. (Der Plural von Status lautet n...

### DIFF
--- a/app/locale/de_DE/Mage_Sales.csv
+++ b/app/locale/de_DE/Mage_Sales.csv
@@ -448,7 +448,7 @@
 "Order State","Bestell Zustand"
 "Order Status","Bestell-Status"
 "Order Status Information","Bestellstatus Information"
-"Order Statuses","Bestellstati &amp; -zustände"
+"Order Statuses","Bestellstatus &amp; -zustände"
 "Order Subtotal","Bestellung Zwischensumme"
 "Order Taxes Report Grouped by Tax Rates","Bestell-Steuer Bericht gruppiert nach Steuersätzen"
 "Order Total","Bestellsumme"


### PR DESCRIPTION
...icht etwa „Stati“, sondern wie der Nominativ und der Genitiv Singular: Status. Im Genitiv und im Plural wird allerdings das u lang ausgesprochen.)