### PR TITLE
Added default configuration for design/email/support

### DIFF
--- a/app/code/community/German/LocalePackDe/etc/config.xml
+++ b/app/code/community/German/LocalePackDe/etc/config.xml
@@ -112,5 +112,12 @@
             </modules>
         </translate>
     </frontend>
+    <default>
+        <design>
+            <email>
+                <support>design_email_support</support>
+            </email>
+        </design>
+    </default>
 
 </config>


### PR DESCRIPTION
Without this default configuration, it was necessary to hit the save button in admin config's design section to get the additional template included.