### PR TITLE
Bestellstatus Rechtschreibung

### DIFF
--- a/app/locale/de_DE/Mage_Sales.csv
+++ b/app/locale/de_DE/Mage_Sales.csv
@@ -448,7 +448,7 @@
 "Order State","Bestell Zustand"
 "Order Status","Bestell-Status"
 "Order Status Information","Bestellstatus Information"
-"Order Statuses","Bestellstati &amp; -zustände"
+"Order Statuses","Bestellstatus &amp; -zustände"
 "Order Subtotal","Bestellung Zwischensumme"
 "Order Taxes Report Grouped by Tax Rates","Bestell-Steuer Bericht gruppiert nach Steuersätzen"
 "Order Total","Bestellsumme"


### PR DESCRIPTION
Moin. Das Wort Stati gibt es [im Duden](http://www.duden.de/rechtschreibung/Status) nicht. Die Mehrzahl von Status (kurzes "u") ist Status (langes "u").