### PR TITLE
Update Mage_Persistent.csv

### DIFF
--- a/app/locale/de_DE/Mage_Persistent.csv
+++ b/app/locale/de_DE/Mage_Persistent.csv
@@ -37,7 +37,7 @@
 "New Customers","Neue Kunden"
 "New Here?","Neuer Kunde?"
 "Password","Passwort"
-"Persist Shopping Cart","Geräte übergreifender Warenkorb"
+"Persist Shopping Cart","Persistenter Warenkorb"
 "Persistence Lifetime (seconds)","Automatisch ausloggen nach (Sekunden)"
 "Persistent Shopping Cart","Gerät übergreifender Warenkorb"
 "Personal Information","Persönliche Informationen"


### PR DESCRIPTION
Siehe http://www.duden.de/suchen/dudenonline/persistent

Persistent ist ein reguläres deutsches Fremdwort. Alternativ wäre noch "Dauerhaft" möglich. Beides klingt weniger gestelzt als "Gerät übergreifender Warenkorb"
