### PR TITLE
Missing translation for account confirmation hint

### DIFF
--- a/app/locale/de_DE/Mage_Customer.csv
+++ b/app/locale/de_DE/Mage_Customer.csv
@@ -13,6 +13,7 @@
 "Account Information","Benutzerkonto Information"
 "Account Sharing Options","Benutzerkonto Verteilungsoptionen"
 "Account confirmation is required. Please, check your email for the confirmation link. To resend the confirmation email please <a href=""%s"">click here</a>.","Kontobestätigung ist erforderlich. Bitte beachten Sie dazu den Bestätigungslink in der E-Mail. Um Ihre Bestätigung noch einmal versenden zu lassen, <a href=""%s"">klicken Sie hier</a>."
+"Account confirmation is required. Please, check your e-mail for confirmation link. To resend confirmation email please <a href=""%s"">click here</a>.","Kontobestätigung ist erforderlich. Bitte beachten Sie dazu den Bestätigungslink in der E-Mail. Um Ihre Bestätigung noch einmal versenden zu lassen, <a href=""%s"">klicken Sie hier</a>."
 "Action","Aktion"
 "Add New Address","Neue Adresse"
 "Add New Customer","Neuer Kunde"


### PR DESCRIPTION
Customer module has a different account confirmation hint than checkout module, when a customer registers at checkout. Added the missing translation.
