### PR TITLE
Propose 'Verwandte Artikel' instead of 'Zubehör'

### DIFF
--- a/app/locale/de_DE/Mage_Catalog.csv
+++ b/app/locale/de_DE/Mage_Catalog.csv
@@ -562,7 +562,7 @@
 "Redirect","Weiterleitung"
 "Redirect URL","Weiterleitungs-URL"
 "Regular Price:","Regulärer Preis:"
-"Related Products","Zubehör"
+"Related Products","Verwandte Artikel"
 "Remove","Entfernen"
 "Remove Product From Websites","Artikel von Websites entfernen"
 "Remove This Item","Diesen Artikel entfernen"


### PR DESCRIPTION
Ich muss zugeben, dass ich gut eineinhalb Stunden gesucht habe und schon langsam an mir Zweifelte als ich für meine Artikel versuchte "Related Products" anzulegen... Auf die Idee die Links der einzelnen Backendmenüeinträge zu untersuchen kam ich dann aus Not und feststellen musste, dass "Related Products" mit "Zubehör" übersetzt wurde. Die bisherige Übersetzung würde ich bei Cross-Selling, nicht aber bei den Verwandten Produkten erwarten. 

Möglicherweise ist es nicht so einfach zu ändern, da alle bisherigen Installationen von der alten Übersetzung auch im Frontend abhängen (sollten die denn jemals das Paket überhaupt aktualisieren, die meisten größeren angepassten Shops, die ich bisher gesehen habe, arbeiten meist nach dem Prinzip "don't touch as long as it works")

Vielleicht findet aber der ein oder andere das Hilfreich und muss nicht stundenlang das Netz durchforsten nur um festzustellen, dass ja dann doch alles da ist :)