### PR TITLE
Apply SUPEE-10888 changes to reset password template

### DIFF
--- a/app/locale/de_DE/template/email/account_password_reset_confirmation.html
+++ b/app/locale/de_DE/template/email/account_password_reset_confirmation.html
@@ -4,7 +4,7 @@
 "var logo_url":"Email Logo Image Url",
 "var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$customer.name":"Customer Name",
-"store url=\"customer/account/resetpassword/\" _query_id=$customer.id _query_token=$customer.rp_token":"Reset Password URL"}
+"store url=\"customer/account/resetpassword/\" _query_id=$customer.rp_customer_id _query_token=$customer.rp_token":"Reset Password URL"}
 @-->
 
 <!--@styles
@@ -22,7 +22,7 @@
             <table cellspacing="0" cellpadding="0" class="action-button" >
                 <tr>
                     <td>
-                        <a href="{{store url="customer/account/resetpassword/" _query_id=$customer.id _query_token=$customer.rp_token}}"><span>Passwort zurücksetzen</span></a>
+                        <a href="{{store url="customer/account/resetpassword/" _query_id=$customer.rp_customer_id _query_token=$customer.rp_token}}"><span>Passwort zurücksetzen</span></a>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
Hi Rico,

Sorry, my German _ist nicht sehr gut_ so I'll have to use English. :)

Recently the SUPEE-10888 Magento security patch has come out and also the new 1.9.3.10 release for Magento community. The patch fixes a bunch of things, and one of the things that is fixed is that the password reset confirmation email no longer has a customer ID anywhere in a link or in the text.

Your language pack overrides one of the changed templates, and we use your pack in one of our shops, so in order to apply the patch I have to apply the patch to your template as well - hence this PR.

This pull request changes the `customer.id` field to `customer.rp_customer_id`, which is a second token, that Magento now uses instead of the customer ID.

What do you think?

Tschüß,

Toon Spin

More info on the Magento patch:
https://magento.com/security/patches/supee-10888
https://devdocs.magento.com/guides/m1x/ce19-ee114/ce1.9_release-notes.html#ce19-19310
